### PR TITLE
feat(hasher): set and hash now accept arguments for the hasher

### DIFF
--- a/inmemory.js
+++ b/inmemory.js
@@ -8,9 +8,8 @@ const proxy = () => through(function (data, enc, cb) {
 })
 
 class InMemoryContentAddressableStorage {
-  constructor (algo = 'sha256', _createHasher = createHasher) {
+  constructor (_createHasher = (cb) => createHasher('sha256', cb)) {
     this._store = new Map()
-    this._algo = algo
     this._createHasher = _createHasher
   }
 
@@ -30,8 +29,9 @@ class InMemoryContentAddressableStorage {
     return stream
   }
 
-  hash (value, cb) {
-    let hasher = this._createHasher(this._algo, (err, hash) => {
+  hash (value, ...args) {
+    let cb = args.pop()
+    let hasher = this._createHasher(...args, (err, hash) => {
       if (err) return cb(err)
       cb(null, hash)
     })
@@ -46,9 +46,10 @@ class InMemoryContentAddressableStorage {
     process.nextTick(() => cb(new Error('value is a not a valid type')))
   }
 
-  set (value, cb) {
+  set (value, ...args) {
+    let cb = args.pop()
     let _value = bl()
-    let hasher = this._createHasher(this._algo, (err, hash) => {
+    let hasher = this._createHasher(...args, (err, hash) => {
       if (err) return cb(err)
       this._store.set(hash, _value)
       cb(null, hash)

--- a/tests/test-fs.js
+++ b/tests/test-fs.js
@@ -9,7 +9,7 @@ require('../lib/test-basics')('fs', fsStore(testdir))
 const test = require('tap').test
 const through = require('through2')
 
-const failHasher = (algo, cb) => {
+const failHasher = cb => {
   process.nextTick(() => cb(new Error('Test Error')))
   return through(() => {})
 }
@@ -23,7 +23,7 @@ test('fs(implementation): directory does not exist', t => {
 
 test('fs(implementation): hash error in hash()', t => {
   t.plan(1)
-  let store = fsStore(testdir, 'noop', failHasher)
+  let store = fsStore(testdir, failHasher)
   store.hash(Buffer.from('asdf'), err => {
     t.type(err, 'Error')
   })
@@ -31,7 +31,7 @@ test('fs(implementation): hash error in hash()', t => {
 
 test('fs(implementation): hash error in set()', t => {
   t.plan(2)
-  let store = fsStore(testdir, 'noop', failHasher)
+  let store = fsStore(testdir, failHasher)
   store.set(Buffer.from('asdf'), err => {
     t.type(err, 'Error')
   })
@@ -70,10 +70,10 @@ test('fs(implementation): filesystem errors, fs.writeFile()', t => {
 
 test('fs(implementation): slow hasher', t => {
   t.plan(2)
-  const slowHasher = (algo, cb) => {
+  const slowHasher = cb => {
     return through(() => setTimeout(() => cb(null, 'asdf'), 100))
   }
-  let store = fsStore(testdir, 'noop', slowHasher)
+  let store = fsStore(testdir, slowHasher)
   let stream = bl()
   store.set(stream, (err, hash) => {
     t.error(err)

--- a/tests/test-inmemory.js
+++ b/tests/test-inmemory.js
@@ -4,14 +4,14 @@ const test = require('tap').test
 const inmemory = require('../inmemory')
 const through = require('through2')
 
-const failHasher = (algo, cb) => {
+const failHasher = (cb) => {
   process.nextTick(() => cb(new Error('Test Error')))
   return through(() => {})
 }
 
 test('inmemory: (implementation) hash error in hash()', t => {
   t.plan(1)
-  let store = inmemory('noop', failHasher)
+  let store = inmemory(failHasher)
   store.hash(Buffer.from('asdf'), err => {
     t.type(err, 'Error')
   })
@@ -19,7 +19,7 @@ test('inmemory: (implementation) hash error in hash()', t => {
 
 test('inmemory: (implementation) hash error in set()', t => {
   t.plan(1)
-  let store = inmemory('noop', failHasher)
+  let store = inmemory(failHasher)
   store.set(Buffer.from('asdf'), err => {
     t.type(err, 'Error')
   })


### PR DESCRIPTION
For cases where the hasher might accept arguments it's not suffient to set them in the constructor.

BREAKING CHANGE: Constructor now only takes a single argument for creating the hasher.